### PR TITLE
FBAllocationTracker: Track allocations call stack addresses.

### DIFF
--- a/FBAllocationTracker/FBAllocationTrackerImpl.h
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.h
@@ -14,6 +14,7 @@
 #import "FBAllocationTrackerDefines.h"
 #import "FBAllocationTrackerFunctors.h"
 #import "FBAllocationTrackerGenerationManager.h"
+#import "FBAllocationTrackerSummary.h"
 
 /**
  FBAllocationTracker is a simple tool that's only purpose is to be able to track
@@ -35,8 +36,8 @@
 namespace FB { namespace AllocationTracker {
 
   struct SingleClassSummary {
-    NSUInteger allocations;
-    NSUInteger deallocations;
+    NSArray<FBSingleObjectAllocation *> *allocatedObjectsInfo;
+    NSArray<NSNumber *> *deallocatedObjectsPointers;
     NSUInteger instanceSize;
   };
 

--- a/FBAllocationTracker/FBAllocationTrackerImpl.h
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.h
@@ -86,6 +86,8 @@ namespace FB { namespace AllocationTracker {
    */
   void markGeneration();
 
+  void runBlockWhileBlockingAllocations(void (^block)());
+
   /**
    Summary for all generations. It will be similar to allocations summary, but grouped by generations.
    */

--- a/FBAllocationTracker/FBAllocationTrackerImpl.h
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.h
@@ -37,7 +37,7 @@ namespace FB { namespace AllocationTracker {
 
   struct SingleClassSummary {
     NSArray<FBSingleObjectAllocation *> *allocatedObjectsInfo;
-    NSArray<NSNumber *> *deallocatedObjectsPointers;
+    NSArray<NSValue *> *deallocatedObjectsPointers;
     NSUInteger instanceSize;
   };
 

--- a/FBAllocationTracker/FBAllocationTrackerManager.h
+++ b/FBAllocationTracker/FBAllocationTrackerManager.h
@@ -38,6 +38,8 @@ BOOL FBIsFBATEnabledInThisBuild(void);
  */
 - (void)startTrackingAllocations;
 
+- (void)runBlockWhileBlockingAllocations:(void (^_Nonnull)(void))block;
+
 /**
  Disable tracking allocations. It will clear all data gathered so far.
  */

--- a/FBAllocationTracker/FBAllocationTrackerManager.mm
+++ b/FBAllocationTracker/FBAllocationTrackerManager.mm
@@ -64,6 +64,10 @@ BOOL FBIsFBATEnabledInThisBuild(void)
   FB::AllocationTracker::beginTracking();
 }
 
+- (void)runBlockWhileBlockingAllocations:(void (^)(void))block {
+  FB::AllocationTracker::runBlockWhileBlockingAllocations(block);
+}
+
 - (void)enableGenerations
 {
   dispatch_sync(_queue, ^{

--- a/FBAllocationTracker/FBAllocationTrackerManager.mm
+++ b/FBAllocationTracker/FBAllocationTrackerManager.mm
@@ -101,11 +101,12 @@ BOOL FBIsFBATEnabledInThisBuild(void)
     NSString *className = NSStringFromClass(aCls);
 
     FBAllocationTrackerSummary *summaryObject =
-    [[FBAllocationTrackerSummary alloc] initWithAllocations:singleSummary.allocations
-                                              deallocations:singleSummary.deallocations
-                                               aliveObjects:singleSummary.allocations - singleSummary.deallocations
+    [[FBAllocationTrackerSummary alloc] initWithAllocations:singleSummary.allocatedObjectsInfo.count
+                                              deallocations:singleSummary.deallocatedObjectsPointers
+                                               aliveObjects:singleSummary.allocatedObjectsInfo.count - singleSummary.deallocatedObjectsPointers.count
                                                   className:className
-                                               instanceSize:singleSummary.instanceSize];
+                                               instanceSize:singleSummary.instanceSize
+                                       allocatedObjectsInfo:singleSummary.allocatedObjectsInfo];
     [array addObject:summaryObject];
   }
 
@@ -119,10 +120,11 @@ BOOL FBIsFBATEnabledInThisBuild(void)
   for (const auto &kv: summary) {
     FBAllocationTrackerSummary *summaryObject =
     [[FBAllocationTrackerSummary alloc] initWithAllocations:0
-                                              deallocations:0
+                                              deallocations:@[]
                                                aliveObjects:kv.second
                                                   className:NSStringFromClass(kv.first)
-                                               instanceSize:class_getInstanceSize(kv.first)];
+                                               instanceSize:class_getInstanceSize(kv.first)
+                                       allocatedObjectsInfo:@[]];
 
     [array addObject:summaryObject];
   }

--- a/FBAllocationTracker/FBAllocationTrackerSummary.h
+++ b/FBAllocationTracker/FBAllocationTrackerSummary.h
@@ -9,18 +9,32 @@
 
 #import <Foundation/Foundation.h>
 
+@class FBSingleObjectAllocation;
+
+@interface FBSingleObjectAllocation : NSObject
+
+@property (nonatomic, readonly, nonnull) NSValue *objectPointer;
+@property (nonatomic, readonly, nullable) NSArray<NSNumber *> *callStackAddresses;
+
+- (nonnull instancetype)initWithObjectPointer:(nonnull NSValue *)objectPointer
+                           callStackAddresses:(nullable NSArray<NSNumber *> *)callStackAddresses;
+
+@end
+
 @interface FBAllocationTrackerSummary : NSObject
 
 @property (nonatomic, readonly) NSUInteger allocations;
-@property (nonatomic, readonly) NSUInteger deallocations;
+@property (nonatomic, readonly, nonnull) NSArray<NSValue *> *deallocations;
 @property (nonatomic, readonly) NSInteger aliveObjects;
 @property (nonatomic, copy, readonly, nonnull) NSString *className;
 @property (nonatomic, readonly) NSUInteger instanceSize;
+@property (nonatomic, readonly, nonnull) NSArray<FBSingleObjectAllocation *> *allocatedObjectsInfo;
 
 - (nonnull instancetype)initWithAllocations:(NSUInteger)allocations
-                              deallocations:(NSUInteger)deallocations
+                              deallocations:(nonnull NSArray<NSNumber *> *)deallocations
                                aliveObjects:(NSInteger)aliveObjects
                                   className:(nonnull NSString *)className
-                               instanceSize:(NSUInteger)instanceSize;
+                               instanceSize:(NSUInteger)instanceSize
+                       allocatedObjectsInfo:(nonnull NSArray<FBSingleObjectAllocation *> *)allocatedObjectsInfo;
 
 @end

--- a/FBAllocationTracker/FBAllocationTrackerSummary.h
+++ b/FBAllocationTracker/FBAllocationTrackerSummary.h
@@ -13,11 +13,11 @@
 
 @interface FBSingleObjectAllocation : NSObject
 
-@property (nonatomic, readonly, nonnull) NSValue *objectPointer;
+@property (weak, nonatomic, readonly, nullable) id object;
 @property (nonatomic, readonly, nullable) NSArray<NSNumber *> *callStackAddresses;
 
-- (nonnull instancetype)initWithObjectPointer:(nonnull NSValue *)objectPointer
-                           callStackAddresses:(nullable NSArray<NSNumber *> *)callStackAddresses;
+- (nonnull instancetype)initWithObject:(nullable id)object
+                    callStackAddresses:(nullable NSArray<NSNumber *> *)callStackAddresses;
 
 @end
 
@@ -31,7 +31,7 @@
 @property (nonatomic, readonly, nonnull) NSArray<FBSingleObjectAllocation *> *allocatedObjectsInfo;
 
 - (nonnull instancetype)initWithAllocations:(NSUInteger)allocations
-                              deallocations:(nonnull NSArray<NSNumber *> *)deallocations
+                              deallocations:(nonnull NSArray<NSValue *> *)deallocations
                                aliveObjects:(NSInteger)aliveObjects
                                   className:(nonnull NSString *)className
                                instanceSize:(NSUInteger)instanceSize

--- a/FBAllocationTracker/FBAllocationTrackerSummary.m
+++ b/FBAllocationTracker/FBAllocationTrackerSummary.m
@@ -9,13 +9,29 @@
 
 #import "FBAllocationTrackerSummary.h"
 
+@implementation FBSingleObjectAllocation : NSObject
+
+- (nonnull instancetype)initWithObjectPointer:(nonnull NSValue *)objectPointer
+                           callStackAddresses:(nullable NSArray<NSNumber *> *)callStackAddresses
+{
+  if ((self = [super init])) {
+    _objectPointer = objectPointer;
+    _callStackAddresses = callStackAddresses;
+  }
+
+  return self;
+}
+
+@end
+
 @implementation FBAllocationTrackerSummary
 
-- (instancetype)initWithAllocations:(NSUInteger)allocations
-                      deallocations:(NSUInteger)deallocations
-                       aliveObjects:(NSInteger)aliveObjects
-                          className:(NSString *)className
-                       instanceSize:(NSUInteger)instanceSize
+- (nonnull instancetype)initWithAllocations:(NSUInteger)allocations
+                              deallocations:(nonnull NSArray<NSNumber *> *)deallocations
+                               aliveObjects:(NSInteger)aliveObjects
+                                  className:(nonnull NSString *)className
+                               instanceSize:(NSUInteger)instanceSize
+                       allocatedObjectsInfo:(nonnull NSArray<FBSingleObjectAllocation *> *)allocatedObjectsInfo;
 {
   if ((self = [super init])) {
     _allocations = allocations;
@@ -23,6 +39,7 @@
     _aliveObjects = aliveObjects;
     _className = className;
     _instanceSize = instanceSize;
+    _allocatedObjectsInfo = allocatedObjectsInfo;
   }
 
   return self;
@@ -30,7 +47,7 @@
 
 -(NSString *)description
 {
-  return [NSString stringWithFormat:@"%@: allocations=%@ deallocations=%@ alive=%@ size=%@", _className, @(_allocations), @(_deallocations), @(_aliveObjects), @(_instanceSize)];
+  return [NSString stringWithFormat:@"%@: allocations=%@ deallocations=%@ alive=%@ size=%@", _className, @(_allocations), @(_deallocations.count), @(_aliveObjects), @(_instanceSize)];
 }
 
 @end

--- a/FBAllocationTracker/FBAllocationTrackerSummary.m
+++ b/FBAllocationTracker/FBAllocationTrackerSummary.m
@@ -11,11 +11,11 @@
 
 @implementation FBSingleObjectAllocation : NSObject
 
-- (nonnull instancetype)initWithObjectPointer:(nonnull NSValue *)objectPointer
-                           callStackAddresses:(nullable NSArray<NSNumber *> *)callStackAddresses
+- (nonnull instancetype)initWithObject:(nullable id)object
+                    callStackAddresses:(nullable NSArray<NSNumber *> *)callStackAddresses
 {
   if ((self = [super init])) {
-    _objectPointer = objectPointer;
+    _object = object;
     _callStackAddresses = callStackAddresses;
   }
 
@@ -27,7 +27,7 @@
 @implementation FBAllocationTrackerSummary
 
 - (nonnull instancetype)initWithAllocations:(NSUInteger)allocations
-                              deallocations:(nonnull NSArray<NSNumber *> *)deallocations
+                              deallocations:(nonnull NSArray<NSValue *> *)deallocations
                                aliveObjects:(NSInteger)aliveObjects
                                   className:(nonnull NSString *)className
                                instanceSize:(NSUInteger)instanceSize


### PR DESCRIPTION
The stack addresses are needed to know the origination of allocations.
In addition the object pointer is also tracked so that it will be
possible to tell which objects whether a single instance was actually
deallocated.